### PR TITLE
File with ext. reference can now be saved

### DIFF
--- a/core/libs/rdf/src/lib/services/rdf.service.ts
+++ b/core/libs/rdf/src/lib/services/rdf.service.ts
@@ -142,7 +142,7 @@ export class RdfService {
 
   saveModel(rdfModel: RdfModel): Observable<any> {
     const rdfContent = this.serializeModel(rdfModel);
-    return this.modelApiService.saveModel(rdfContent);
+    return this.modelApiService.saveModel(rdfContent, rdfModel.getAbsoluteAspectModelFileName());
   }
 
   loadModelLatest(): Observable<RdfModel> {


### PR DESCRIPTION
When saving aspect models with external references, these were mixed with each other.